### PR TITLE
Use ExpDev07/coronavirus-tracker-api API wrapper instead of raw requests to it

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,4 +1,4 @@
-import requests
+import COVID19Py
 
 correspondence = {
    "Thailand":0,
@@ -466,18 +466,18 @@ correspondence = {
 }
 
 def get_world_cases():
-    r = requests.get('https://coronavirus-tracker-api.herokuapp.com/v2/latest')
-    data = r.json()
-    return data['latest']['confirmed'], data['latest']['deaths'], data['latest']['recovered']
+    covid19 = COVID19Py.COVID19()
+    data = covid19.getLatest()
+    return data['confirmed'], data['deaths'], data['recovered']
 
 def get_country_id(name: str):
     formatstr = name.replace(',', '.')
     return correspondence[formatstr]
 
 def get_country_stats(c_id: int):
-    r = requests.get(f'https://coronavirus-tracker-api.herokuapp.com/v2/locations/{c_id}')
-    data = r.json()
-    return data['location']['latest']['confirmed'], data['location']['latest']['deaths'], data['location']['latest']['recovered']
+    covid19 = COVID19Py.COVID19()
+    data = covid19.getLocationById(c_id)
+    return data['latest']['confirmed'], data['latest']['deaths'], data['latest']['recovered']
 
 def get_country_list():
     l = ["World"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+COVID19Py


### PR DESCRIPTION
Instead of implementing the API calls within MM-coder/coronavirus-wallpaper, it'd be a better approach to use a wrapper.

COVID19Py will stay up to date to the latest changes of the original API and its use makes API calls one less thing to worry about.